### PR TITLE
pin x/sys version when calling go get -modcacherw

### DIFF
--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -6,7 +6,6 @@ FROM golang:1.16.4-nanoserver AS builder
 ARG BASE_DIR
 ARG NAME
 ARG VERSION
-ENV GOFLAGS=-modcacherw
 COPY cmd $BASE_DIR/cmd
 COPY pkg $BASE_DIR/pkg
 WORKDIR $BASE_DIR/pkg/common
@@ -14,9 +13,9 @@ RUN go test -v
 WORKDIR $BASE_DIR/cmd/bash
 # go mod tidy fails in windows CI due to permissions of module cache. Each dependency needs to be fetched with -modcacherw flag
 # see golang.org/issue/31481
-RUN go mod tidy
-# RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
-# RUN go get -modcacherw golang.org/x/sys
+# RUN go mod tidy
+RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
+RUN go get -modcacherw golang.org/x/sys@v0.0.0-20210507161434-a76c4d0a0096
 # can't test bash on windows
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=amd64& go build -a -o %NAME%_%VERSION%_darwin_amd_64
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=arm64& go build -a -o %NAME%_%VERSION%_darwin_arm_64

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -15,7 +15,7 @@ WORKDIR $BASE_DIR/cmd/bash
 # see golang.org/issue/31481
 # RUN go mod tidy
 RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
-RUN go get -modcacherw golang.org/x/sys@v0.0.0-20210507161434-a76c4d0a0096
+RUN go get -modcacherw golang.org/x/sys@v0.0.0-20210514084401-e8d321eab015
 # can't test bash on windows
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=amd64& go build -a -o %NAME%_%VERSION%_darwin_amd_64
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=arm64& go build -a -o %NAME%_%VERSION%_darwin_arm_64

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -6,6 +6,7 @@ FROM golang:1.16.4-nanoserver AS builder
 ARG BASE_DIR
 ARG NAME
 ARG VERSION
+ENV GOFLAGS=-modcacherw
 COPY cmd $BASE_DIR/cmd
 COPY pkg $BASE_DIR/pkg
 WORKDIR $BASE_DIR/pkg/common
@@ -13,9 +14,9 @@ RUN go test -v
 WORKDIR $BASE_DIR/cmd/bash
 # go mod tidy fails in windows CI due to permissions of module cache. Each dependency needs to be fetched with -modcacherw flag
 # see golang.org/issue/31481
-# RUN go mod tidy
-RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
-RUN go get -modcacherw golang.org/x/sys
+RUN go mod tidy
+# RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
+# RUN go get -modcacherw golang.org/x/sys
 # can't test bash on windows
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=amd64& go build -a -o %NAME%_%VERSION%_darwin_amd_64
 RUN set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=arm64& go build -a -o %NAME%_%VERSION%_darwin_arm_64

--- a/src/cmd/bash/go.mod
+++ b/src/cmd/bash/go.mod
@@ -5,6 +5,6 @@ go 1.16
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 
 require (
-	golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096
+	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
 	jenkinsci.org/plugins/durabletask/common v0.0.0-00010101000000-000000000000
 )

--- a/src/cmd/bash/go.sum
+++ b/src/cmd/bash/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096 h1:5PbJGn5Sp3GEUjJ61aYbUP6RIo3Z3r2E4Tv9y2z8UHo=
-golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
More windows CI issues where `go get -modcacherw` is not working correctly. 
`go.mod` pins the version of the module, however when calling `go get -modcacherw  golang.org/x/sys`, it will retrieve the latest version. If the version do not line up, go attempts to upgrade the dependency and you get the `go.mod permission denied` issue again.  A version tag must be added to prevent this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
