### PR TITLE
Update packaged golang version to 1.19.1

### DIFF
--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.16.4-buster AS builder
+FROM golang:1.19.1-buster AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.16.4-nanoserver AS builder
+FROM golang:1.19.1-nanoserver AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd


### PR DESCRIPTION
This change updates the packaged golang version from 1.16 to 1.19.1. 1.16 has multiple known vulnerabilities which trips up vulnerability scanners. Updating to the latest golang version that is available at https://hub.docker.com/_/golang.

Once this is merged, I intend to upgrade the durable-task plugin with the new version.


Replaces https://github.com/jenkinsci/lib-durable-task/pull/59
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
