### PR TITLE
[JENKINS-70428] create binary wrappers for linux ppc64le and arm64

### DIFF
--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -16,6 +16,8 @@ RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ${NAME}_darwin_amd64
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -o ${NAME}_darwin_arm64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ${NAME}_linux_64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -a -o ${NAME}_linux_32
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o ${NAME}_linux_ppc64le
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o ${NAME}_linux_aarch64
 WORKDIR $BASE_DIR/cmd/windows
 RUN go mod tidy
 # can't test windows on linux

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -19,6 +19,8 @@ RUN set CGO_ENABLED=0&& set GOOS=darwin&& set GOARCH=amd64&& go build -a -o %NAM
 RUN set CGO_ENABLED=0&& set GOOS=darwin&& set GOARCH=arm64&& go build -a -o %NAME%_darwin_arm64
 RUN set CGO_ENABLED=0&& set GOOS=linux&& set GOARCH=amd64&& go build -a -o %NAME%_linux_64
 RUN set CGO_ENABLED=0&& set GOOS=linux&& set GOARCH=386&& go build -a -o %NAME%_linux_32
+RUN set CGO_ENABLED=0&& set GOOS=linux&& set GOARCH=ppc64le&& go build -a -o %NAME%_linux_ppc64le
+RUN set CGO_ENABLED=0&& set GOOS=linux&& set GOARCH=arm64&& go build -a -o %NAME%_linux_aarch64
 WORKDIR $BASE_DIR/cmd/windows
 # RUN go mod tidy
 RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common


### PR DESCRIPTION
name the binaries according to the os.arch value of java 
requires changes in the durable-task-plugin so the correct names are found.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
