### PR TITLE
Bump golang.org/x/sys from 0.0.0-20210514084401-e8d321eab015 to 0.7.0

### DIFF
--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -13,7 +13,7 @@ WORKDIR $BASE_DIR/cmd/bash
 # see golang.org/issue/31481
 # RUN go mod tidy
 RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
-RUN go get -modcacherw golang.org/x/sys@v0.0.0-20210514084401-e8d321eab015
+RUN go get -modcacherw golang.org/x/sys@v0.7.0
 # can't test bash on windows
 RUN set CGO_ENABLED=0&& set GOOS=darwin&& set GOARCH=amd64&& go build -a -o %NAME%_darwin_amd64
 RUN set CGO_ENABLED=0&& set GOOS=darwin&& set GOARCH=arm64&& go build -a -o %NAME%_darwin_arm64
@@ -24,7 +24,7 @@ RUN set CGO_ENABLED=0&& set GOOS=linux&& set GOARCH=arm64&& go build -a -o %NAME
 WORKDIR $BASE_DIR/cmd/windows
 # RUN go mod tidy
 RUN go get -modcacherw jenkinsci.org/plugins/durabletask/common
-RUN go get -modcacherw golang.org/x/sys@v0.0.0-20210514084401-e8d321eab015
+RUN go get -modcacherw golang.org/x/sys@v0.7.0
 RUN go test -v
 RUN set CGO_ENABLED=0& set GOOS=windows& set GOARCH=amd64& go build -a -o %NAME%_win_64.exe
 RUN set CGO_ENABLED=0& set GOOS=windows& set GOARCH=386& go build -a -o %NAME%_win_32.exe

--- a/src/cmd/bash/go.mod
+++ b/src/cmd/bash/go.mod
@@ -5,6 +5,6 @@ go 1.16
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 
 require (
-	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
+	golang.org/x/sys v0.7.0
 	jenkinsci.org/plugins/durabletask/common v0.0.0-00010101000000-000000000000
 )

--- a/src/cmd/bash/go.sum
+++ b/src/cmd/bash/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/src/cmd/windows/go.mod
+++ b/src/cmd/windows/go.mod
@@ -5,6 +5,6 @@ go 1.16
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 
 require (
-	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
+	golang.org/x/sys v0.7.0
 	jenkinsci.org/plugins/durabletask/common v0.0.0-00010101000000-000000000000
 )

--- a/src/cmd/windows/go.sum
+++ b/src/cmd/windows/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
bumping x/sys to 0.7.0 as opposed to 0.1.0 in #78 (which it would supersede)

This would resolve the following dependabot alerts:
https://github.com/jenkinsci/lib-durable-task/security/dependabot/1
https://github.com/jenkinsci/lib-durable-task/security/dependabot/2

### Testing done
Validated in https://github.com/jenkinsci/durable-task-plugin/pull/176

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
