### PR TITLE
Upgrade version of Go to remove critical vulnerability in scan

### DIFF
--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.19.3-buster AS builder
+FROM golang:1.20.4-buster AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.19.3-nanoserver AS builder
+FROM golang:1.20.4-nanoserver AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd

--- a/src/cmd/bash/go.mod
+++ b/src/cmd/bash/go.mod
@@ -1,6 +1,6 @@
 module jenkinsci.org/plugins/durabletask/bash
 
-go 1.16
+go 1.20
 
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 

--- a/src/cmd/windows/go.mod
+++ b/src/cmd/windows/go.mod
@@ -1,6 +1,6 @@
 module jenkinsci.org/plugins/durabletask/windows
 
-go 1.16
+go 1.20
 
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 

--- a/src/pkg/common/go.mod
+++ b/src/pkg/common/go.mod
@@ -1,3 +1,3 @@
 module jenkinsci.org/plugins/durabletask/common
 
-go 1.16
+go 1.20


### PR DESCRIPTION
This removes CVE-2023-24538 which is a 9.8 critical due to older version of go being used

See https://nvd.nist.gov/vuln/detail/CVE-2023-24538

### Testing done
This upgrades the version of golang from 1.19 to 1.20. It should be compatible.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
