### PR TITLE
Upgrade to golang 1.24.7 to address vulnerabilities

### DIFF
--- a/src/Dockerfile.linux
+++ b/src/Dockerfile.linux
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.21.9-bullseye AS builder
+FROM golang:1.24.7-bookworm AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd

--- a/src/Dockerfile.windows
+++ b/src/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG BASE_DIR=/durabletask
 ARG NAME=durable_task_monitor
 
-FROM golang:1.21.9-nanoserver AS builder
+FROM golang:1.24.7-nanoserver AS builder
 ARG BASE_DIR
 ARG NAME
 COPY cmd $BASE_DIR/cmd

--- a/src/cmd/bash/go.mod
+++ b/src/cmd/bash/go.mod
@@ -1,6 +1,6 @@
 module jenkinsci.org/plugins/durabletask/bash
 
-go 1.21
+go 1.24
 
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 

--- a/src/cmd/windows/go.mod
+++ b/src/cmd/windows/go.mod
@@ -1,6 +1,6 @@
 module jenkinsci.org/plugins/durabletask/windows
 
-go 1.21
+go 1.24
 
 replace jenkinsci.org/plugins/durabletask/common => ../../pkg/common
 

--- a/src/pkg/common/go.mod
+++ b/src/pkg/common/go.mod
@@ -1,3 +1,3 @@
 module jenkinsci.org/plugins/durabletask/common
 
-go 1.21
+go 1.24


### PR DESCRIPTION
This PR is to resolve the following advisories flagged in XRAY scans of Jenkins images:

- [CVE-2025-22871](https://nvd.nist.gov/vuln/detail/CVE-2025-22871) - 9.1 Critical
- [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790) - 9.8 Critical

### Testing done

This upgrades the version of golang from 1.21 to 1.24. This is promised to be a compatible upgrade, save for some requirement changes called out in the [release announcement](https://tip.golang.org/doc/go1.24#ports), namely requiring Linux Kernel 3.2 or later (3.2 has been EOL since 2018)

```
$ go version target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_*
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_darwin_amd64: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_darwin_arm64: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_linux_32: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_linux_64: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_linux_aarch64: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_linux_ppc64le: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_win_32.exe: go1.24.7
target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_win_64.exe: go1.24.7

$ target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_darwin_amd64 -h
Usage of target/classes/io/jenkins/plugins/lib-durable-task/durable_task_monitor_darwin_amd64:
  -controldir string
    	working directory
  -cookiename string
    	name of the jenkins server cookie
  -cookieval string
    	value of the jenkins server cookie
  -daemon
    	Immediately free binary from parent process
  -debug
    	noisy output to log
  -log string
    	full path of the log file
  -output string
    	(optional) if recording output, full path of the output file
  -result string
    	full path of the result file
  -script string
    	full path of the script to be launched
  -shell string
    	(optional) interpreter to use
```

The true test would be upgrade to a revision of https://github.com/jenkinsci/durable-task-plugin including the new binaries.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
